### PR TITLE
Fix <label>s in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,13 +60,13 @@ import {ANGULARCLASS_MATCH_CONTROL_DIRECTIVES} from '@angularclass/match-control
 
       <div>
         <label>
-           password:
+          Password:
           <input ngControl="newPassword" required>
         </label>
         <ac-form-errors control="newPassword" [errors]="{'required': 'password is required'}"></ac-form-errors>
 
       <label>
-        Username:
+        Password Again:
         <input ngControl="newPasswordAgain" ac-match-control="newPassword">
       </label>
 


### PR DESCRIPTION
Should be "Password" and "Password Again" instead of "Password" and "Username"
